### PR TITLE
Use JS syntax in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,27 @@ methods can be called in-line as opposed composing function _a priori_.
 
 ## Usage
 
-    let f = require('functify');
+```js
+let f = require('functify');
 
-    let numbers = f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+let numbers = f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     
-    for (let odd in numbers.filter(n => n % 2)) {
-        console.log(n);  // 1, 3, 5, ...
-    }
+for (let odd in numbers.filter(n => n % 2)) {
+    console.log(n);  // 1, 3, 5, ...
+}
     
-    for (let even in numbers.filter(n => !(n % 2))) {
-        console.log(n);  // 2, 4, 6, ...
-    }
+for (let even in numbers.filter(n => !(n % 2))) {
+    console.log(n);  // 2, 4, 6, ...
+}
     
-    for (let [odd, even] in numbers.split(n => n % 2, n => !(n % 2)).zip()) {
-        console.log(`odd = ${odd}, even = ${even}`);  // [1, 2], [3, 4], ...
-    }
+for (let [odd, even] in numbers.split(n => n % 2, n => !(n % 2)).zip()) {
+    console.log(`odd = ${odd}, even = ${even}`);  // [1, 2], [3, 4], ...
+}
     
-    for (let square in numbers.take(3).map(n => n * n)) {
-        console.log(square);  // 1, 4, 9
-    }
+for (let square in numbers.take(3).map(n => n * n)) {
+    console.log(square);  // 1, 4, 9
+}
+```
     
 ## Maps and Objects
 
@@ -50,20 +52,24 @@ The new Map class in ES6 has three methods which return iterators:
 
 A Map instance itself can be used as an iterator, e.g.
 
-    let map = new Map();
-    map.set('x', 5);
-    map.set('y', 10);
+```js
+let map = new Map();
+map.set('x', 5);
+map.set('y', 10);
     
-    for (let [k, v] of map) {
-        console.log(`map['${k}'] = ${v}`);  // map['x'] = 5, map['y'] = 10
-    }
+for (let [k, v] of map) {
+    console.log(`map['${k}'] = ${v}`);  // map['x'] = 5, map['y'] = 10
+}
+```
     
 `functify` wraps Map instances and exposes versions of `keys()`, `values()`, 
 and `entries()` that methods like `map()` and `filter()` can be chained to, e.g.
 
-    for (let v2 of functify(map).entries().map(pair => pair[1] * pair[1])) {
-        console.log(v2);  // 25, 100
-    }
+```js
+for (let v2 of functify(map).entries().map(pair => pair[1] * pair[1])) {
+    console.log(v2);  // 25, 100
+}
+```
     
 Note: chaining in the opposite order is not allowed because map may return 
 something that isn't an entry, i.e. a [key, value] pair.
@@ -76,14 +82,16 @@ arrays which consume memory.
 `functify` wraps Object instances, adding `keys()`, `values()`, and `entries()`
 methods along with all the other methods that `functify` provides.
 
-    let obj = {
-        x: 5,
-        y: 10
-    }
+```js
+let obj = {
+    x: 5,
+    y: 10
+}
     
-    for (let [k, v] of functify(obj)) {
-        console.log(`obj['${k}'] = ${v}`);  // obj['x'] = 5, obj['y'] = 10
-    }
+for (let [k, v] of functify(obj)) {
+    console.log(`obj['${k}'] = ${v}`);  // obj['x'] = 5, obj['y'] = 10
+}
+```
     
 The combines the simple creation and access syntax of Objects with the powerful
 iterators provided by Map.
@@ -93,38 +101,44 @@ iterators provided by Map.
 functify wraps iterables in an object with methods to performan map, reduce, 
 filter, etc.  This object is also iterable.  Here's how:
 
-    class Functified {
-        constructor(iterable) {
-            this.iterable = iterable;
-        }
+```js
+class Functified {
+    constructor(iterable) {
+        this.iterable = iterable;
+    }
 
-        *[Symbol.iterator]() {
-            for (let value of this.iterable) {
-                yield value;
-            }
+    *[Symbol.iterator]() {
+        for (let value of this.iterable) {
+            yield value;
         }
+    }
 
-        // various instance and static methods
+    // various instance and static methods
+```
 
 In order to make it easier to write methods on Functified there's also a static
 method `fromGenerator(generator)` which takes a generator and returns an iterator.
 
-    static fromGenerator(generator) {
-        return funcitify({
-            [Symbol.iterator]: generator
-        });
-    }
+```js
+static fromGenerator(generator) {
+    return funcitify({
+        [Symbol.iterator]: generator
+    });
+}
+```
     
 This allows methods to be easily implemented.  Here's the implementation for `map`:
 
-    map(callback) {
-        var iterable = this.iterable;
-        return Functified.fromGenerator(function* () {
-            for (let value of iterable) {
-                yield callback(value);
-            }
-        });
-    }
+```js
+map(callback) {
+    var iterable = this.iterable;
+    return Functified.fromGenerator(function* () {
+        for (let value of iterable) {
+            yield callback(value);
+        }
+    });
+}
+```
 
 ## Pausable
 
@@ -133,36 +147,40 @@ with those values, and then resume taking values where you left of at some point
 in the future.  Normally you would have to resort to creating an iterator and 
 calling `next()` manually, e.g.
 
-    var numbers = [1,2,3,4,5];
-    var iterator = numbers[Symbol.iterator]();
+```js
+var numbers = [1,2,3,4,5];
+var iterator = numbers[Symbol.iterator]();
     
-    for (let i = 0; i < 2; i++) {
-        console.log(iterator.next().value);
+for (let i = 0; i < 2; i++) {
+    console.log(iterator.next().value);
+}
+    
+// do something else
+    
+while (true) {
+    let result = iterator.next();
+    if (result.done) {
+        break;
     }
-    
-    // do something else
-    
-    while (true) {
-        let result = iterator.next();
-        if (result.done) {
-            break;
-        }
-        let value = iterator.next().value;
-        let square = value * value;
-        console.log(value * value);
-    }
+    let value = iterator.next().value;
+    let square = value * value;
+    console.log(value * value);
+}
+```
     
 The `toPausable()` creates an iterator Below is an example of how this works.
 
-    var numbers = [1,2,3,4,5];
-    var pausableNumbers = numbers.toPausable();
-    
-    for (let n of pausableNumbers.take(2)) {
-        console.log(n);     // 1 2
-    }
-    
-    // do something else
-    
-    for (let n of pausableNumbers.map(x => x * x).takeUntil(x => x > 16)) {
-        console.log(n);     // 9 16
-    }
+```js
+var numbers = [1,2,3,4,5];
+var pausableNumbers = numbers.toPausable();
+
+for (let n of pausableNumbers.take(2)) {
+    console.log(n);     // 1 2
+}
+
+// do something else
+
+for (let n of pausableNumbers.map(x => x * x).takeUntil(x => x > 16)) {
+    console.log(n);     // 9 16
+}
+```


### PR DESCRIPTION
This makes it slightly easier to read.

--
No other changes were made.